### PR TITLE
fix: hide KEYBOARD_HACK with PM_UNSET instead of removing it

### DIFF
--- a/Src/options.c
+++ b/Src/options.c
@@ -823,7 +823,8 @@ dosetopt(int optno, int value, int force, char *new_opts)
 	new_opts[(optno == EMACSMODE) ? VIMODE : EMACSMODE] = 0;
     } else if (optno == SUNKEYBOARDHACK) {
 	/* for backward compatibility */
-	keyboardhackchar = (value ? '`' : '\0');
+	if (value)
+	    keyboardhackchar = '`';
     }
     new_opts[optno] = value;
     if (optno == BANGHIST || optno == SHINSTDIN)

--- a/Src/options.c
+++ b/Src/options.c
@@ -823,8 +823,7 @@ dosetopt(int optno, int value, int force, char *new_opts)
 	new_opts[(optno == EMACSMODE) ? VIMODE : EMACSMODE] = 0;
     } else if (optno == SUNKEYBOARDHACK) {
 	/* for backward compatibility */
-	if (value)
-	    keyboardhackchar = '`';
+	keyboardhackchar = (value ? '`' : '\0');
     }
     new_opts[optno] = value;
     if (optno == BANGHIST || optno == SHINSTDIN)

--- a/Src/params.c
+++ b/Src/params.c
@@ -237,8 +237,6 @@ static const struct gsu_scalar ifs_gsu =
 { ifsgetfn, ifssetfn, stdunsetfn };
 static const struct gsu_scalar underscore_gsu =
 { underscoregetfn, nullstrsetfn, stdunsetfn };
-static const struct gsu_scalar keyboard_hack_gsu =
-{ keyboardhackgetfn, keyboardhacksetfn, stdunsetfn };
 #ifdef USE_LOCALE
 static const struct gsu_scalar lc_blah_gsu =
 { strgetfn, lcsetfn, stdunsetfn };
@@ -313,7 +311,6 @@ IPDEF2("TERMINFO_DIRS", terminfodirs_gsu, PM_UNSET),
 IPDEF2("WORDCHARS", wordchars_gsu, 0),
 IPDEF2("IFS", ifs_gsu, PM_DONTIMPORT | PM_RESTRICTED),
 IPDEF2("_", underscore_gsu, PM_DONTIMPORT),
-IPDEF2("KEYBOARD_HACK", keyboard_hack_gsu, PM_DONTIMPORT),
 IPDEF2("0", argzero_gsu, 0),
 
 #ifdef USE_LOCALE

--- a/Src/params.c
+++ b/Src/params.c
@@ -237,6 +237,8 @@ static const struct gsu_scalar ifs_gsu =
 { ifsgetfn, ifssetfn, stdunsetfn };
 static const struct gsu_scalar underscore_gsu =
 { underscoregetfn, nullstrsetfn, stdunsetfn };
+static const struct gsu_scalar keyboard_hack_gsu =
+{ keyboardhackgetfn, keyboardhacksetfn, stdunsetfn };
 #ifdef USE_LOCALE
 static const struct gsu_scalar lc_blah_gsu =
 { strgetfn, lcsetfn, stdunsetfn };
@@ -311,6 +313,7 @@ IPDEF2("TERMINFO_DIRS", terminfodirs_gsu, PM_UNSET),
 IPDEF2("WORDCHARS", wordchars_gsu, 0),
 IPDEF2("IFS", ifs_gsu, PM_DONTIMPORT | PM_RESTRICTED),
 IPDEF2("_", underscore_gsu, PM_DONTIMPORT),
+IPDEF2("KEYBOARD_HACK", keyboard_hack_gsu, PM_DONTIMPORT | PM_UNSET),
 IPDEF2("0", argzero_gsu, 0),
 
 #ifdef USE_LOCALE
@@ -4746,7 +4749,7 @@ keyboardhackgetfn(UNUSED(Param pm))
 
 /**/
 void
-keyboardhacksetfn(UNUSED(Param pm), char *x)
+keyboardhacksetfn(Param pm, char *x)
 {
     if (x) {
 	int len, i;
@@ -4759,13 +4762,20 @@ keyboardhacksetfn(UNUSED(Param pm), char *x)
 	for (i = 0; i < len; i++) {
 	    if (!isascii(STOUC(x[i]))) {
 		zwarn("KEYBOARD_HACK can only contain ASCII characters");
+		free(x);
 		return;
 	    }
 	}
 	keyboardhackchar = len ? STOUC(x[0]) : '\0';
+	if (keyboardhackchar)
+	    pm->node.flags &= ~PM_UNSET;
+	else
+	    pm->node.flags |= PM_UNSET;
 	free(x);
-    } else
+    } else {
 	keyboardhackchar = '\0';
+	pm->node.flags |= PM_UNSET;
+    }
 }
 
 /* Function to get value for special parameter `histchar' */


### PR DESCRIPTION
### Issue for this PR

Closes #9

### Type of change

- [x] Bug fix

### What does this PR do?

Hides the `KEYBOARD_HACK` special parameter from `typeset`/`echo` listings when empty or unset, instead of removing it entirely. The approach uses `PM_UNSET`:

- **`IPDEF2("KEYBOARD_HACK", ...)`** registered with `PM_DONTIMPORT | PM_UNSET` — starts hidden by default
- **`keyboardhacksetfn`** toggles `PM_UNSET` based on value:
  - Non-empty ASCII value → `pm->node.flags &= ~PM_UNSET` (visible)
  - Empty string after unmetafy → `pm->node.flags |= PM_UNSET` (hidden)
  - NULL (param being unset via `stdunsetfn`) → `pm->node.flags |= PM_UNSET` (hidden)

The `SUN_KEYBOARD_HACK` option and `keyboardhackchar` variable continue working independently — the option handler sets the hack character directly without touching the parameter's visibility.

Also fixes a pre-existing memory leak: `keyboardhacksetfn` was missing `free(x)` on the ASCII validation error return path.

### How did you verify your code works?

Code review and production-readiness adversarial review — see [`REVIEW-2026-05-25T18:54:46+07:00.md`](https://github.com/HaleTom/zinit-module-pr10/blob/main/REVIEW-2026-05-25T18%3A54%3A46%2B07%3A00.md).

Changes in `Src/params.c`:
- `IPDEF2` flags: `PM_DONTIMPORT` → `PM_DONTIMPORT | PM_UNSET` (1 insertion)
- `keyboardhacksetfn`: added PM_UNSET toggling + memory leak fix (9 insertions, 3 deletions)

### Related

- Issue #9: KEYBOARD_HACK special parameter is unnecessary legacy pollution

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR